### PR TITLE
Feature/settings enviorment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ SilverStripe\Core\Injector\Injector:
     class: Violet88\BugsnagModule\BugsnagLogger
     constructor:
       - '%$Violet88\BugsnagModule\Bugsnag'
+SilverStripe\SiteConfig\SiteConfig:
+  extensions:
+    - Violet88\BugsnagModule\BugsnagSiteConfigExtension
 ```
 For using the CLI command to sent your current release revision to Bugsnag, add the following to your routes yaml
 ```yaml

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -4,7 +4,7 @@ After:
   - "#rootroutes"
   - "#coreroutes"
 Before:
-  - "routes"
+  - "approutes"
 ---
 SilverStripe\Control\Director:
   rules:

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,0 +1,11 @@
+---
+Name: mymoduleroutes
+After:
+  - "#rootroutes"
+  - "#coreroutes"
+Before:
+  - "routes"
+---
+SilverStripe\Control\Director:
+  rules:
+    "admin/settings/bugsnag//$Action": 'Violet88\BugsnagModule\BugsnagSiteConfigExtension_Controller'

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -22,7 +22,7 @@ class BugsnagLogger extends AbstractProcessingHandler
      * @param array $record
      * @return void
      */
-    protected function write(array $record)
+    protected function write($record): void
     {
         if (isset($record['context'])) {
             if (!isset($record['context']['exception'])) {

--- a/src/BugsnagSiteConfigExtension.php
+++ b/src/BugsnagSiteConfigExtension.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Violet88\BugsnagModule;
+
+use App\Extensions\SiteConfigExtension;
+use LeKoala\CmsActions\CustomAction;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\HeaderField;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\Debug;
+
+class BugsnagSiteConfigExtension extends Extension {
+
+  public function updateCMSFields(FieldList $fields) {
+
+    $bugsnagState = $this->getBugsnagActiveState();
+    $bugsnagReleaseStage = $this->getBugsnagReleaseStage();
+
+    $fields->addFieldsToTab('Root.Bugsnag', [
+      HeaderField::create('Bugsnag settings'),
+
+      FieldGroup::create([
+        TextField::create('BugsnagActiveState', 'Bugsnag active state')
+          ->setValue($bugsnagState['code'])
+          ->setAttribute('style', $bugsnagState['style'])
+          ->setReadonly(true),
+
+        TextField::create('BugsnagReleaseStage', 'Bugsnag release stage')
+          ->setValue($bugsnagReleaseStage['code'])
+          ->setAttribute('style', $bugsnagReleaseStage['style'])
+          ->setReadonly(true)
+      ]),
+
+      HeaderField::create('Bugsnag testing buttons'),
+      FieldGroup::create([
+        FormAction::create('doForceError', 'Force error')
+          ->setAttribute('onclick', "location.href='admin/settings/bugsnag/doForceError'")
+          ->addExtraClass('btn action btn-danger'),
+        FormAction::create('doForceWarning', 'Force warning')
+          ->setAttribute('onclick', "location.href='admin/settings/bugsnag/doForceWarning'")
+          ->addExtraClass('btn action btn-warning'),
+        FormAction::create('doForceInfo', 'Force info')
+          ->setAttribute('onclick', "location.href='admin/settings/bugsnag/doForceInfo'")
+          ->addExtraClass('btn action btn-info')
+      ])
+
+    ]);
+
+    return $fields;
+  }
+
+  private function getBugsnagActiveState() {
+    $state = Environment::getEnv('BUGSNAG_ACTIVE');
+
+    switch($state) {
+      case false:
+        return [
+          "code" => "ENV variable 'BUGSNAG_ACTIVE' not set",
+          "style" => $this->getInputStyling('bad'),
+        ];
+      case "":
+        return [
+          "code" => "Active state not set",
+          "style" => $this->getInputStyling('warning'),
+        ];
+      case "false":
+        return [
+          "code" => "Bugsnag inactive",
+          "style" => $this->getInputStyling('bad'),
+        ];
+      case "true":
+        return [
+          "code" => "Bugsnag active",
+          "style" => $this->getInputStyling('good'),
+        ];
+    }
+  } 
+
+  private function getBugsnagReleaseStage() {
+    $state = Environment::getEnv('BUGSNAG_RELEASE_STAGE');
+
+    switch($state) {
+      case false:
+        return [
+          "code" => "ENV variable 'BUGSNAG_RELEASE_STAGE' not set, default to 'development' stage.",
+          "style" => $this->getInputStyling('bad'),
+        ];
+      case "":
+        return [
+          "code" => "Release stage not set, default to 'development' stage.",
+          "style" => $this->getInputStyling('warning'),
+        ];
+      default:
+      return [
+        "code" => $state,
+        "style" => $this->getInputStyling('good'),
+      ];
+    }
+  } 
+
+  private function getInputStyling($type) {
+    switch($type) {
+      case 'good': return "background-color: #d1e7dd; color: #0f5132; border-color: #badbcc;";
+      case 'warning': return "background-color: #fff3cd; color: #664d03; border-color: #ffecb5;";
+      case 'bad': return "background-color: #f8d7da; color: #842029; border-color: #f5c2c7;";
+    }
+  }
+}

--- a/src/BugsnagSiteConfigExtension_Controller.php
+++ b/src/BugsnagSiteConfigExtension_Controller.php
@@ -12,6 +12,7 @@ use SilverStripe\SiteConfig\SiteConfig;
 
 class BugsnagSiteConfigExtension_Controller extends LeftAndMain {
   private static $url_segment = 'admin/settings/bugsnag';
+  private static $menu_title = 'Bugsnag';
 
   private static $allowed_actions = [
     'doForceError',

--- a/src/BugsnagSiteConfigExtension_Controller.php
+++ b/src/BugsnagSiteConfigExtension_Controller.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Violet88\BugsnagModule;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use SilverStripe\Admin\CMSMenu;
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\SiteConfig\SiteConfig;
+
+class BugsnagSiteConfigExtension_Controller extends LeftAndMain {
+  private static $url_segment = 'admin/settings/bugsnag';
+
+  private static $allowed_actions = [
+    'doForceError',
+    'doForceWarning',
+    'doForceInfo',
+  ];
+
+  public function init() {
+    parent::init();
+
+    CMSMenu::remove_menu_item('Violet88-BugsnagModule-BugsnagSiteConfigExtension_Controller');
+  }
+
+  public function doForceError($request) {
+    $bugsnag = Injector::inst()->get(Bugsnag::class);
+    $bugsnag->sendException(new RuntimeException("Force BugSnag error"), 'error');
+
+    return $this->redirect('/admin/settings#Root_Bugsnag');
+  }
+
+  public function doForceWarning($request) {
+    $bugsnag = Injector::inst()->get(Bugsnag::class);
+    $bugsnag->sendException(new RuntimeException("Force BugSnag warning"), 'warning');
+
+    return $this->redirect('/admin/settings#Root_Bugsnag');
+  }
+
+  public function doForceInfo($request) {
+    $bugsnag = Injector::inst()->get(Bugsnag::class);
+    $bugsnag->sendException(new RuntimeException("Force BugSnag info"), 'info');
+
+    return $this->redirect('/admin/settings#Root_Bugsnag');
+  }
+}


### PR DESCRIPTION
Adds a settings tab with information on the current bugsnag activity and release stage. Also introduces buttons to force test warnings, info messages and errors

Summarized changes in this pull request:
* Bugsnag settings tab in siteconfig

Tested this module in the following environments:
* docker php 8.1

Checklist:
- [x] Updated documentation
- [ ] Wrote tests for new Functionality (if applicable)
- [ ] All tests, including existing ones, pass


@JanSneeuw 
